### PR TITLE
Fix insufficient dtype in HDF export

### DIFF
--- a/utils/samplefiles.py
+++ b/utils/samplefiles.py
@@ -206,29 +206,31 @@ class SampleFile:
             # dict as a new dataset
             group = hdf_file.create_group('injection_samples')
             for key, value in iteritems(self.data['injection_samples']):
+                dtype = 'float64' if key == 'event_time' else 'float32'
                 if value is not None:
                     group.create_dataset(name=key,
                                          shape=value.shape,
-                                         dtype='f4',
+                                         dtype=dtype,
                                          data=value)
                 else:
                     group.create_dataset(name=key,
                                          shape=None,
-                                         dtype='f4')
+                                         dtype=dtype)
 
             # Create group for noise_samples and save every item of the
             # dict as a new dataset
             group = hdf_file.create_group('noise_samples')
             for key, value in iteritems(self.data['noise_samples']):
+                dtype = 'float64' if key == 'event_time' else 'float32'
                 if value is not None:
                     group.create_dataset(name=key,
                                          shape=value.shape,
-                                         dtype='f4',
+                                         dtype=dtype,
                                          data=value)
                 else:
                     group.create_dataset(name=key,
                                          shape=None,
-                                         dtype='f4')
+                                         dtype=dtype)
 
             # Create group for injection_parameters and save every item of the
             # dict as a new dataset
@@ -237,12 +239,12 @@ class SampleFile:
                 if value is not None:
                     group.create_dataset(name=key,
                                          shape=value.shape,
-                                         dtype='f4',
+                                         dtype='float64',
                                          data=value)
                 else:
                     group.create_dataset(name=key,
                                          shape=None,
-                                         dtype='f4')
+                                         dtype='float64')
 
             # Create group for normalization_parameters and save every item
             # of the dict as a new attribute


### PR DESCRIPTION
As it turns out, GPS times such as "1000000042" cannot accurately
be stored as float32 ("f4") numbers, which means that the
"event_time" will get corrupted when saving the generated data as
an HDF file. This commit fixes the data type for event_times to
float64, which should solve the problem.
Additionally, all injection_parameters are now also stored as
float64 numbers. Technically, this *shouldn't* be necessary, since
these parameters should all live in a more reasonable value range,
but better safe than sorry :)